### PR TITLE
The groupId com.dremio.plugin (singular) installs to

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.dremio.plugin</groupId>
+  <groupId>com.dremio.plugins</groupId>
   <version>3.3.1-201907291852280797-df23756</version>
   <artifactId>dremio-snowflake-plugin</artifactId>
   <name>Dremio Snowflake Community Connector</name>


### PR DESCRIPTION
.m2/repository/com/dremio/plugin (singluar)
while other dremio-oss plugins with groupId com.dremio.plugins (plural)
install to .m2/repository/com/dremio/plugins (plural)

In dremio-oss they changed from singular to plural groupId at ~3.x