### PR TITLE
snowflake does not support nested aggregations

### DIFF
--- a/src/main/java/com/dremio/exec/store/jdbc/conf/SnowflakeConf.java
+++ b/src/main/java/com/dremio/exec/store/jdbc/conf/SnowflakeConf.java
@@ -71,6 +71,10 @@ public class SnowflakeConf extends AbstractArpConf<SnowflakeConf> {
         JdbcStoragePlugin.Config config) {
       return new SnowflakeSchemaFetcher(name, dataSource, timeout, config);
     }
+
+    public boolean supportsNestedAggregations() {
+      return false;
+    }
   }
 
   /*


### PR DESCRIPTION
Before this PR, dremio was generating `sum(sum(column))` queries, that are invalid and failed on SF.