### PR TITLE
Add support for timestampdiff_week function

### DIFF
--- a/src/main/resources/arp/implementation/snowflake-arp.yaml
+++ b/src/main/resources/arp/implementation/snowflake-arp.yaml
@@ -750,6 +750,45 @@ expressions:
             - "timestamp"
           return: "integer"
     - names:
+        - "timestampdiff_week" # https://docs.snowflake.com/en/sql-reference/functions/timestampdiff.html
+      signatures:
+        - args:
+            - "timestamp"
+            - "timestamp"
+          return: "integer"
+        - args:
+            - "time"
+            - "time"
+          return: "integer"
+        - args:
+            - "date"
+            - "date"
+          return: "integer"
+        - args:
+            - "timestamp"
+            - "date"
+          return: "integer"
+        - args:
+            - "timestamp"
+            - "time"
+          return: "integer"
+        - args:
+            - "time"
+            - "timestamp"
+          return: "integer"
+        - args:
+            - "time"
+            - "date"
+          return: "integer"
+        - args:
+            - "date"
+            - "time"
+          return: "integer"
+        - args:
+            - "date"
+            - "timestamp"
+          return: "integer"
+    - names:
       - "timestampdiff_year" #https://docs.snowflake.net/manuals/sql-reference/functions/timestampdiff.html
       signatures:
         - args:


### PR DESCRIPTION
Add support for missing `WEEK` variant of the `TIMESTAMPDIFF` function.

- Function has the same signature as other variants
- Tested with Snowflake