### PR TITLE
Add support for convert_timezone function

### DIFF
--- a/src/main/resources/arp/implementation/snowflake-arp.yaml
+++ b/src/main/resources/arp/implementation/snowflake-arp.yaml
@@ -973,6 +973,23 @@ expressions:
             - time
           rewrite: "WEEK({0})"
 
+    - names:
+        - convert_timezone # https://docs.snowflake.com/en/sql-reference/functions/convert_timezone.html
+      signatures:
+        - return: timestamp
+          args:
+            - varchar
+            - timestamp
+          # Remove timezone from the result, otherwise Dremio will ignore it
+          rewrite: "TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE({0}, {1}))"
+        - return: timestamp
+          args:
+            - varchar
+            - varchar
+            - timestamp
+          # Remove timezone from the result, otherwise Dremio will ignore it. Supports only timestamps without timezone.
+          rewrite: "TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE({0}, {1}, {2}))"
+
     # Math functions
     - names:
         - "log" #https://docs.snowflake.net/manuals/sql-reference/functions/log.html


### PR DESCRIPTION
Add support for both variants of the `CONVERT_TIMEZONE` function.

- We have to strip timezone from the results, otherwise Dremio will ignore it (or convert to UTC)
- Tested with Snowflake